### PR TITLE
ENH Added `axis=None` functionality to ranking.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,9 +118,9 @@ After you have installed ``la``, run the suite of unit tests::
     >>> import la
     >>> la.test()
     <snip>
-    Ran 3027 tests in 1.175s
+    Ran 3038 tests in 1.308s
     OK
-    <nose.result.TextTestResult run=3027 errors=0 failures=0> 
+    <nose.result.TextTestResult run=3038 errors=0 failures=0> 
     
 The ``la`` package contains C extensions that speed up common alignment
 operations such as adding two unaligned larrys. If the C extensions don't

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -22,6 +22,7 @@ la 0.6
 - datime.time and datetime.datetime labels can now be (HDF5) archived
 - la.align() can now skip the axes you do not wish to align
 - Upgrade numpydoc from 0.3.1 to 0.4 to support Sphinx 1.0.1
+- la.farray.ranking() and larry ranking method support `axis=None`
 
 **Breakage from la 0.5**
 

--- a/la/deflarry.py
+++ b/la/deflarry.py
@@ -2992,7 +2992,7 @@ class larry(object):
 
         Parameters
         ----------
-        axis : int, optional
+        axis : {int, None} optional
             Axis to rank over. Default axis is 0.
         norm: str, optional
             A string that specifies the normalization:

--- a/la/farray/normalize.py
+++ b/la/farray/normalize.py
@@ -131,7 +131,7 @@ def ranking(x, axis=0, norm='-1,1'):
     ----------
     x : ndarray
         Data to be ranked.
-    axis : int, optional
+    axis : {int, None} optional
         Axis to rank over. Default axis is 0.
     norm: str, optional
         A string that specifies the normalization:
@@ -161,6 +161,9 @@ def ranking(x, axis=0, norm='-1,1'):
     example, the output will have the same min and max along all columns.
     
     """
+    if axis is None:
+        ranked_x = ranking(x.reshape(-1), norm=norm)
+        return ranked_x.reshape(*x.shape)
     ax = axis
     if ax < 0:
         # This converts a negative axis to the equivalent positive axis

--- a/la/farray/tests/farray_test.py
+++ b/la/farray/tests/farray_test.py
@@ -343,7 +343,7 @@ class Test_ranking(unittest.TestCase):
                             [-1.0, -1.0,    1.0,   1.0],
                             [ 1.0,  1.0,   -1.0,   1.0],
                             [ 1.0,  1.0,   -1.0,   1.0]])
-        desired *= 0.533333333
+        desired *= 8.0 / 15
         actual = ranking(x, axis=None)
         assert_almost_equal(actual, desired)
 
@@ -357,7 +357,7 @@ class Test_ranking(unittest.TestCase):
                             [-1.0,  0.0,    1.0,   1.0],
                             [ 1.0,  nan,   -1.0,   1.0],
                             [ 1.0,  0.0,   -1.0,   1.0]])
-        desired *= 0.61538462
+        desired *= 8.0 / 13
         actual = ranking(x, axis=None)
         assert_almost_equal(actual, desired)
         

--- a/la/farray/tests/farray_test.py
+++ b/la/farray/tests/farray_test.py
@@ -326,6 +326,40 @@ class Test_ranking(unittest.TestCase):
         actual = ranking(x, axis=0)
         assert_almost_equal(actual, desired)
 
+    def test_ranking_15(self):
+        "farray.ranking_15"
+        x = np.array([ -np.inf, nan, 1.0, np.inf])  
+        desired = np.array([-1.0, nan, 0.0, 1.0])    
+        actual = ranking(x, axis=None)
+        assert_almost_equal(actual, desired)
+
+    def test_ranking_16(self):
+        "farray.ranking_16"
+        x = np.array([[ 1.0,   1.0,   1.0,   1.0],
+                      [ 1.0,   1.0,   2.0,   2.0],
+                      [ 2.0,   2.0,   1.0,   2.0],
+                      [ 2.0,   2.0,   1.0,   2.0]]) 
+        desired = np.array([[-1.0, -1.0,   -1.0,  -1.0],
+                            [-1.0, -1.0,    1.0,   1.0],
+                            [ 1.0,  1.0,   -1.0,   1.0],
+                            [ 1.0,  1.0,   -1.0,   1.0]])
+        desired *= 0.533333333
+        actual = ranking(x, axis=None)
+        assert_almost_equal(actual, desired)
+
+    def test_ranking_17(self):
+        "farray.ranking_17"
+        x = np.array([[ nan,   1.0,   1.0,   1.0],
+                      [ 1.0,   1.5,   2.0,   2.0],
+                      [ 2.0,   nan,   1.0,   2.0],
+                      [ 2.0,   1.5,   1.0,   2.0]]) 
+        desired = np.array([[ nan, -1.0,   -1.0,  -1.0],
+                            [-1.0,  0.0,    1.0,   1.0],
+                            [ 1.0,  nan,   -1.0,   1.0],
+                            [ 1.0,  0.0,   -1.0,   1.0]])
+        desired *= 0.61538462
+        actual = ranking(x, axis=None)
+        assert_almost_equal(actual, desired)
         
 class Test_geometric_mean(unittest.TestCase):
     "Test farray.geometric_mean"

--- a/la/tests/deflarry_test.py
+++ b/la/tests/deflarry_test.py
@@ -3263,6 +3263,141 @@ class Test_calc(unittest.TestCase):
         self.assert_(label == p.label, printfail(label, p.label, 'label'))
         self.assert_(noreference(p, lx), 'Reference found') 
 
+    def test_ranking_10(self):
+        "farray.ranking_10"
+        x = np.array([[ nan],
+                      [ nan],
+                      [ nan]])
+        lx = larry(x)
+        p = lx.ranking(0)
+        t = np.array([[ nan],
+                      [ nan],
+                      [ nan]])
+        label = [range(3), range(1)]
+        msg = printfail(t, p.x, 'x')  
+        t[np.isnan(t)] = self.nancode
+        p[p.isnan()] = self.nancode               
+        self.assert_((abs(t - p.x) < self.tol).all(), msg)
+        self.assert_(label == p.label, printfail(label, p.label, 'label'))
+        self.assert_(noreference(p, lx), 'Reference found') 
+
+    def test_ranking_11(self):
+        "farray.ranking_11"
+        x = np.array([[ nan, nan],
+                      [ nan, nan],
+                      [ nan, nan]])  
+        lx = larry(x)
+        p = lx.ranking(0)
+        t = np.array([[ nan, nan],
+                      [ nan, nan],
+                      [ nan, nan]])
+        label = [range(3), range(2)]
+        msg = printfail(t, p.x, 'x')  
+        t[np.isnan(t)] = self.nancode
+        p[p.isnan()] = self.nancode               
+        self.assert_((abs(t - p.x) < self.tol).all(), msg)
+        self.assert_(label == p.label, printfail(label, p.label, 'label'))
+        self.assert_(noreference(p, lx), 'Reference found') 
+
+    def test_ranking_12(self):
+        "farray.ranking_12"
+        x = np.array([[ nan, nan, nan]])  
+        lx = larry(x)
+        p = lx.ranking(1)
+        t = np.array([[ nan, nan, nan]])      
+        label = [range(1), range(3)]
+        msg = printfail(t, p.x, 'x')  
+        t[np.isnan(t)] = self.nancode
+        p[p.isnan()] = self.nancode               
+        self.assert_((abs(t - p.x) < self.tol).all(), msg)
+        self.assert_(label == p.label, printfail(label, p.label, 'label'))
+        self.assert_(noreference(p, lx), 'Reference found') 
+        
+    def test_ranking_13(self):
+        "farray.ranking_13"
+        x = np.array([ 1.0, np.inf, 2.0])  
+        lx = larry(x)
+        p = lx.ranking(0)
+        t = np.array([-1.0, 1.0, 0.0])     
+        label = [range(3)]
+        msg = printfail(t, p.x, 'x')  
+        t[np.isnan(t)] = self.nancode
+        p[p.isnan()] = self.nancode               
+        self.assert_((abs(t - p.x) < self.tol).all(), msg)
+        self.assert_(label == p.label, printfail(label, p.label, 'label'))
+        self.assert_(noreference(p, lx), 'Reference found') 
+
+    def test_ranking_14(self):
+        "farray.ranking_14"
+        x = np.array([ -np.inf, nan, 1.0, np.inf])  
+        lx = larry(x)
+        p = lx.ranking(0)
+        t = np.array([-1.0, nan, 0.0, 1.0])    
+        label = [range(4)]
+        msg = printfail(t, p.x, 'x')  
+        t[np.isnan(t)] = self.nancode
+        p[p.isnan()] = self.nancode               
+        self.assert_((abs(t - p.x) < self.tol).all(), msg)
+        self.assert_(label == p.label, printfail(label, p.label, 'label'))
+        self.assert_(noreference(p, lx), 'Reference found') 
+
+    def test_ranking_15(self):
+        "farray.ranking_15"
+        x = np.array([ -np.inf, nan, 1.0, np.inf])  
+        lx = larry(x)
+        p = lx.ranking(None)
+        t = np.array([-1.0, nan, 0.0, 1.0])    
+        label = [range(4)]
+        msg = printfail(t, p.x, 'x')  
+        t[np.isnan(t)] = self.nancode
+        p[p.isnan()] = self.nancode               
+        self.assert_((abs(t - p.x) < self.tol).all(), msg)
+        self.assert_(label == p.label, printfail(label, p.label, 'label'))
+        self.assert_(noreference(p, lx), 'Reference found') 
+
+    def test_ranking_16(self):
+        "farray.ranking_16"
+        x = np.array([[ 1.0,   1.0,   1.0,   1.0],
+                      [ 1.0,   1.0,   2.0,   2.0],
+                      [ 2.0,   2.0,   1.0,   2.0],
+                      [ 2.0,   2.0,   1.0,   2.0]]) 
+        lx = larry(x)
+        p = lx.ranking(None)
+        t = np.array([[-1.0, -1.0,   -1.0,  -1.0],
+                      [-1.0, -1.0,    1.0,   1.0],
+                      [ 1.0,  1.0,   -1.0,   1.0],
+                      [ 1.0,  1.0,   -1.0,   1.0]])
+        t *= 0.533333333
+        label = [range(4), range(4)]
+        msg = printfail(t, p.x, 'x')  
+        t[np.isnan(t)] = self.nancode
+        p[p.isnan()] = self.nancode               
+        self.assert_((abs(t - p.x) < self.tol).all(), msg)
+        self.assert_(label == p.label, printfail(label, p.label, 'label'))
+        self.assert_(noreference(p, lx), 'Reference found') 
+
+    def test_ranking_17(self):
+        "farray.ranking_17"
+        x = np.array([[ nan,   1.0,   1.0,   1.0],
+                      [ 1.0,   1.5,   2.0,   2.0],
+                      [ 2.0,   nan,   1.0,   2.0],
+                      [ 2.0,   1.5,   1.0,   2.0]]) 
+        lx = larry(x)
+        p = lx.ranking(None)
+        x = x.T  
+        t = np.array([[ nan, -1.0,   -1.0,  -1.0],
+                      [-1.0,  0.0,    1.0,   1.0],
+                      [ 1.0,  nan,   -1.0,   1.0],
+                      [ 1.0,  0.0,   -1.0,   1.0]])
+        t *= 0.61538462
+        label = [range(4), range(4)]
+        msg = printfail(t, p.x, 'x')  
+        t[np.isnan(t)] = self.nancode
+        p[p.isnan()] = self.nancode               
+        self.assert_((abs(t - p.x) < self.tol).all(), msg)
+        self.assert_(label == p.label, printfail(label, p.label, 'label'))
+        self.assert_(noreference(p, lx), 'Reference found') 
+
     def test_movingrank_1(self):
         "larry.movingrank_1"    
         t = self.x6 

--- a/la/tests/deflarry_test.py
+++ b/la/tests/deflarry_test.py
@@ -3105,12 +3105,8 @@ class Test_calc(unittest.TestCase):
         with np.errstate(invalid='ignore', divide='ignore'):
             p = lx.ranking(axis=0)
         label = [range(3), range(5)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found') 
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
 
     def test_ranking_2(self):
         "larry.ranking_2"
@@ -3124,12 +3120,8 @@ class Test_calc(unittest.TestCase):
         with np.errstate(invalid='ignore', divide='ignore'):
             p = lx.ranking()
         label = [range(3), range(5)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found') 
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
 
     def test_ranking_3(self):
         "larry.ranking_3"
@@ -3144,12 +3136,8 @@ class Test_calc(unittest.TestCase):
                       [ 1.0,   0.0,   0.5,  -0.5,  -1.0]])                    
         p = lx.ranking(axis=1)
         label = [range(4), range(5)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found')
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
         
     def test_ranking_4(self):
         "larry.ranking_4"  
@@ -3158,12 +3146,8 @@ class Test_calc(unittest.TestCase):
         t = np.array([[1.0],[-1.0], [0.0]])
         p = lx.ranking(axis=0)
         label = [range(3), range(1)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found')
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
 
     def test_ranking_5(self):
         "larry.ranking_5"  
@@ -3173,12 +3157,8 @@ class Test_calc(unittest.TestCase):
         with np.errstate(invalid='ignore', divide='ignore'):
             p = lx.ranking(axis=1)
         label = [range(3), range(1)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found')
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
         
     def test_ranking_6(self):
         "larry.ranking_6"
@@ -3194,12 +3174,8 @@ class Test_calc(unittest.TestCase):
         with np.errstate(invalid='ignore', divide='ignore'):
             p = lx.ranking()
         label = [range(4), range(5)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found')      
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
 
     def test_ranking_7(self):
         "larry.ranking_7"
@@ -3214,12 +3190,8 @@ class Test_calc(unittest.TestCase):
                       [ 0.0,   1.0 ,   0.0,  0.0  ,  -1.0]])                    
         p = lx.ranking(1)
         label = [range(4), range(5)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found')
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
 
     def test_ranking_8(self):
         "larry.ranking_8"
@@ -3234,12 +3206,8 @@ class Test_calc(unittest.TestCase):
                       [ 2.0/3,    1.0,  2.0/3,   1.0]])                    
         p = lx.ranking(0)
         label = [range(4), range(4)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found')
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
         
     def test_ranking_9(self):
         "larry.ranking_9"
@@ -3256,12 +3224,8 @@ class Test_calc(unittest.TestCase):
         t = t.T                                       
         p = lx.ranking(1)
         label = [range(4), range(4)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found') 
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
 
     def test_ranking_10(self):
         "farray.ranking_10"
@@ -3274,12 +3238,8 @@ class Test_calc(unittest.TestCase):
                       [ nan],
                       [ nan]])
         label = [range(3), range(1)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found') 
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
 
     def test_ranking_11(self):
         "farray.ranking_11"
@@ -3292,12 +3252,8 @@ class Test_calc(unittest.TestCase):
                       [ nan, nan],
                       [ nan, nan]])
         label = [range(3), range(2)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found') 
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
 
     def test_ranking_12(self):
         "farray.ranking_12"
@@ -3306,12 +3262,8 @@ class Test_calc(unittest.TestCase):
         p = lx.ranking(1)
         t = np.array([[ nan, nan, nan]])      
         label = [range(1), range(3)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found') 
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
         
     def test_ranking_13(self):
         "farray.ranking_13"
@@ -3320,12 +3272,8 @@ class Test_calc(unittest.TestCase):
         p = lx.ranking(0)
         t = np.array([-1.0, 1.0, 0.0])     
         label = [range(3)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found') 
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
 
     def test_ranking_14(self):
         "farray.ranking_14"
@@ -3334,12 +3282,8 @@ class Test_calc(unittest.TestCase):
         p = lx.ranking(0)
         t = np.array([-1.0, nan, 0.0, 1.0])    
         label = [range(4)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found') 
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
 
     def test_ranking_15(self):
         "farray.ranking_15"
@@ -3348,12 +3292,8 @@ class Test_calc(unittest.TestCase):
         p = lx.ranking(None)
         t = np.array([-1.0, nan, 0.0, 1.0])    
         label = [range(4)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found') 
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
 
     def test_ranking_16(self):
         "farray.ranking_16"
@@ -3367,14 +3307,10 @@ class Test_calc(unittest.TestCase):
                       [-1.0, -1.0,    1.0,   1.0],
                       [ 1.0,  1.0,   -1.0,   1.0],
                       [ 1.0,  1.0,   -1.0,   1.0]])
-        t *= 0.533333333
+        t *= 8.0 / 15 
         label = [range(4), range(4)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found') 
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
 
     def test_ranking_17(self):
         "farray.ranking_17"
@@ -3389,14 +3325,10 @@ class Test_calc(unittest.TestCase):
                       [-1.0,  0.0,    1.0,   1.0],
                       [ 1.0,  nan,   -1.0,   1.0],
                       [ 1.0,  0.0,   -1.0,   1.0]])
-        t *= 0.61538462
+        t *= 8.0 / 13
         label = [range(4), range(4)]
-        msg = printfail(t, p.x, 'x')  
-        t[np.isnan(t)] = self.nancode
-        p[p.isnan()] = self.nancode               
-        self.assert_((abs(t - p.x) < self.tol).all(), msg)
-        self.assert_(label == p.label, printfail(label, p.label, 'label'))
-        self.assert_(noreference(p, lx), 'Reference found') 
+        t = la.larry(t, label)
+        ale(p, t, original=lx)
 
     def test_movingrank_1(self):
         "larry.movingrank_1"    

--- a/la/tests/deflarry_test.py
+++ b/la/tests/deflarry_test.py
@@ -2982,7 +2982,7 @@ class Test_calc(unittest.TestCase):
         "larry.move_sum_7"
         t = np.array([[ nan, nan, nan, nan],
                       [ 2.0, 2.0, nan, 2.0],
-                      [ 1.0, 1.0, nan, 2.0]])                                            
+                      [ 1.0, 1.0, nan, 2.0]])
         label = [[0, 1, 2], [0, 1, 2, 3]]
         p = self.l2.move_sum(2, axis=0)
         msg = printfail(t, p.x, 'x')


### PR DESCRIPTION
Closes #32

The change affects la.farray.ranking() as well as larry's ranking
method. In addition to adding unit tests for `axis=None`, I also ported
over some of the newer farray tests to larry tests, since it appeared
that was how things had been working.
