### PR TITLE
Fix errors with Python 3.3.2 on Ubuntu 13.10

### DIFF
--- a/la/external/prettytable.py
+++ b/la/external/prettytable.py
@@ -2,7 +2,12 @@
 pretty table code was copied from http://code.activestate.com/recipes/267662/
 """
 from __future__ import print_function
-import cStringIO, operator
+import operator
+
+try:
+    from cStringIO import StringIO
+except ImportError:  # Python 3
+    from io import StringIO
 
 def indent(rows, hasHeader=False, headerChar='-', delim=' | ', justify='left',
            separateRows=False, prefix='', postfix='', wrapfunc=lambda x:x):
@@ -34,7 +39,7 @@ def indent(rows, hasHeader=False, headerChar='-', delim=' | ', justify='left',
                                  len(delim)*(len(maxWidths)-1))
     # select the appropriate justify method
     justify = {'center':str.center, 'right':str.rjust, 'left':str.ljust}[justify.lower()]
-    output=cStringIO.StringIO()
+    output = StringIO()
     if separateRows: print(rowSeparator, file=output)
     for physicalRows in logicalRows:
         for row in physicalRows:

--- a/la/farray/__init__.py
+++ b/la/farray/__init__.py
@@ -1,5 +1,5 @@
 
-from misc import *
-from normalize import *
-from group import *
-from move import *
+from .misc import *
+from .normalize import *
+from .group import *
+from .move import *

--- a/la/flabel.py
+++ b/la/flabel.py
@@ -1,6 +1,9 @@
 "label (list of lists) functions"
 
-from itertools import izip
+try:
+    import itertools.izip as zip
+except ImportError:  # Python 3
+    pass
 
 import numpy as np
 
@@ -74,7 +77,7 @@ except ImportError:
         [0, 1]
                   
         """
-        list1map = dict(izip(list1, xrange(len(list1))))
+        list1map = dict(zip(list1, xrange(len(list1))))
         if ignore_unmappable:
             idx = [list1map[i] for i in list2 if i in list1map]
         else:
@@ -151,7 +154,7 @@ except ImportError:
         [3]
         
         """
-        list1map = dict(izip(list1, xrange(len(list1))))
+        list1map = dict(zip(list1, xrange(len(list1))))
         index_missing = []
         index = [fill] * len(list2)
         i = -1


### PR DESCRIPTION
I installed larry by cloning the git repository, then using `pip3 install --user --editable` with the path to the cloned repo.

After doing so, I was unable to `import la` in IPython 0.13.2 and Python 3.3.2 without making the changes in this one commit.

It seems others have contributed Python 3–related changes to the source. I can't see any indication that Python 3 is "officially" supported by larry, but it seems strange that others would be running it on Python 3 without having also encountered, and fixed, these errors.
